### PR TITLE
add prismjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "path": "^0.12.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "prismjs": "^1.26.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",


### PR DESCRIPTION
I added the prismJs dependency to the project because it seems that you only added the type definitions for it, which was causing a module resolution error. I added the version matching the types version, if there is an update, or you would like it to be updated you know how to do that 😅

There is not much information in the contributions doc so If you have any suggestions on a better approach to contributing, please let me know

I apologize for making a pull request to the main branch, as there is no other branch established yet. I hope this is not a problem for you. If you prefer a different workflow, please let me know as well.