### PR TITLE
Disable react display name error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "next/core-web-vitals",
   "rules": {
-    "react/display-name": [0],
-    "import/no-anonymous-default-export": [0]
+    "react/display-name": "off",
+    "import/no-anonymous-default-export": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "extends": "next/core-web-vitals",
-  "react/display-name": [2, { "ignoreTranspilerName":true }]
+  "rules": {
+    "react/display-name": [0],
+    "import/no-anonymous-default-export": [0]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "react/display-name": [2, { "ignoreTranspilerName":true }]
 }


### PR DESCRIPTION
### Preventing build !! 
it seems exporting default unnamed functions is common practice within this project, so disabling the rule seems like the best solution, although id recommend naming the functions

Rules added to eslint.rc: 
- "react/display-name"
- "import/no-anonymous-default-export"

the two go hand in hand