### PR TITLE
Fix Navigation Issue: Homepage 'Get Started' Button

### DIFF
--- a/components/ui/Hero/index.tsx
+++ b/components/ui/Hero/index.tsx
@@ -29,7 +29,7 @@ export default () => {
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
           <LinkItem
-            href="/"
+            href="/components"
             variant="shiny"
             className="inline-block w-full hover:bg-zinc-700 sm:w-auto"
           >


### PR DESCRIPTION
## Description

This pull request addresses the issue #46 where clicking on the 'Get Started' button on the homepage did not navigate to the correct destination.

## Changes Made

- Modified the navigation functionality of the 'Get Started' button to correctly redirect users to [https://www.floatui.com/components](https://www.floatui.com/components).

## Additional Information

![Screenshot (1382)](https://github.com/MarsX-dev/floatui/assets/96189881/0874af9f-27b4-4480-b8f6-096dc36febea)