### PR TITLE
fix: CTA section navigation issue on homepage

### DIFF
--- a/components/ui/CTA/index.tsx
+++ b/components/ui/CTA/index.tsx
@@ -12,7 +12,7 @@ export default () => (
       </p>
       <div className="flex flex-wrap items-center justify-center gap-3">
         <LinkItem
-          href="/"
+          href="/components"
           variant="shiny"
           className="inline-block w-full hover:bg-zinc-700 sm:w-auto"
         >


### PR DESCRIPTION
## Description

This pull request addresses the issue #48 where clicking on the 'Get Started' button on the homepage did not navigate to the correct destination.

## Changes Made

- Modified the navigation functionality of the 'Get Started' button to correctly redirect users to [https://www.floatui.com/components](https://www.floatui.com/components).

## Additional Information

![Screenshot (1384)](https://github.com/MarsX-dev/floatui/assets/96189881/a8e494c8-833b-4221-964f-be4ac7992134)