### PR TITLE
Fix Typo Star on GithHub -> Star on GitHub

### DIFF
--- a/components/HeroBgGradient.tsx
+++ b/components/HeroBgGradient.tsx
@@ -8,12 +8,11 @@ export default ({
   height?: number;
 }) => (
   <svg
-    width="653"
     height={height}
     viewBox="0 0 653 444"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    className={mergeTW(className)}
+    className={mergeTW(className, "w-full sm:w-[653px] sm:h-auto")}
   >
     <g filter="url(#filter0_f_3249_6957)">
       <path

--- a/components/ui/Hero/index.tsx
+++ b/components/ui/Hero/index.tsx
@@ -42,7 +42,7 @@ export default () => {
             target="_blank"
           >
             <IconGithub className="w-5 h-5" />
-            Star on GithHub
+            Star on GitHub
           </LinkItem>
         </div>
       </div>


### PR DESCRIPTION
I noticed there's a typo in Float UI's home page

- Changed **Star on GithHub** to **Star on GitHub**