### PR TITLE
fix: change 'for' in react components to 'htmlFor'

### DIFF
--- a/previewsComponents/FUIUsernameInput.jsx
+++ b/previewsComponents/FUIUsernameInput.jsx
@@ -9,7 +9,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 export default function FUIUsernameInput() {
     return (
         <div className="max-w-md px-4 mx-auto mt-12">
-            <label for="username" className="block py-2 text-gray-500">
+            <label htmlFor="username" className="block py-2 text-gray-500">
                 Username
             </label>
             <div className="flex items-center text-gray-400 border rounded-md">

--- a/previewsComponents/FUIWebsiteUrlInput.jsx
+++ b/previewsComponents/FUIWebsiteUrlInput.jsx
@@ -9,7 +9,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 export default function FUIWebsiteUrlInput() {
     return (
         <div className="max-w-md px-4 mx-auto mt-12">
-            <label for="website-url" className="block py-2 text-gray-500">
+            <label htmlFor="website-url" className="block py-2 text-gray-500">
                 Website URL
             </label>
             <div className="flex items-center text-gray-400 border rounded-md">


### PR DESCRIPTION
2 react components had a `for` attribute in `label` tags. `for` in JavaScript is a reserved keyword, so react uses `htmlFor` instead.

![Screenshot from 2023-12-28 22-03-18](https://github.com/MarsX-dev/floatui/assets/77718741/2963b78d-4c17-4a92-8053-b0e612ebb0e6)

This produced the following error in the console when copy pasting those components into a react app:

![Screenshot from 2023-12-28 22-20-37](https://github.com/MarsX-dev/floatui/assets/77718741/f361cc70-de40-45bc-b8f8-22d4f339f30b)

This pr fixes this issue in both those files.