### PR TITLE
Update Footer Year to 2024 in Footer.tsx

### DIFF
--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -85,7 +85,7 @@ export default () => (
       </div>
       <div className="text-sm custom-screen text-center border-t border-zinc-800">
         <div className="text-zinc-300 py-8">
-          &copy; 2023 Float UI. All rights reserved.
+          &copy; 2024 Float UI. All rights reserved.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updated the copyright year in Footer.tsx from 2023 to 2024 to reflect the current year. This change ensures the footer remains accurate and maintains the website’s professionalism.